### PR TITLE
Ensure that force parameter will be respected

### DIFF
--- a/app/Jobs/RegisterEpisodesFeed.php
+++ b/app/Jobs/RegisterEpisodesFeed.php
@@ -37,7 +37,7 @@ class RegisterEpisodesFeed extends Job implements ShouldQueue
     {
         $this->id = $feed['id'];
         $this->url = $feed['url'];
-        $this->force = false;
+        $this->force = $force;
     }
 
     /**


### PR DESCRIPTION
O parâmetro `force` existe, porém não está sendo utilizado.